### PR TITLE
商品情報編集機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -35,9 +35,9 @@ class ItemsController < ApplicationController
 
   def update
     if @item.update(item_params)
-      redirect_to item_path(@item)
+      redirect_to item_path(@item), notice: 'Item was successfully updated.'
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -28,14 +28,9 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def edit
-    if current_user.id != @item.user_id || @item.purchase.blank?
-    else
-      redirect_to root_path
-    end
   end
 
   def update

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,8 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  # before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :set_item, only: [:show, :edit, :update]
   # before_action :move_to_index, only: [:edit, :update, :destroy]
+  before_action :check_user, only: [:edit, :update]
 
   def index
     @items = Item.includes(:user).order('created_at DESC')
@@ -30,26 +31,20 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
-  # def edit
-  # @item ||= Item.find(params[:id])
-  # Rails.logger.debug "current_user.id: #{current_user.id}"
-  # Rails.logger.debug "@item: #{@item.inspect}"
+  def edit
+    if current_user.id != @item.user_id || @item.purchase.blank?
+    else
+      redirect_to root_path
+    end
+  end
 
-  # if current_user.id != @item.user_id || @item.purchase.present?
-  # redirect_to root_path
-  # else
-  # render :edit
-  # end
-  # end
-
-  # def update
-  # @item.update(item_params)
-  # if @item.valid?
-  # redirect_to item_path(@item)
-  # else
-  # render :edit
-  # end
-  # end
+  def update
+    if @item.update(item_params)
+      redirect_to item_path(@item)
+    else
+      render :edit
+    end
+  end
 
   def destroy
     # return unless @item.destroy
@@ -59,8 +54,18 @@ class ItemsController < ApplicationController
 
   private
 
+  def set_item
+    @item = Item.find(params[:id])
+  end
+
   def item_params
     params.require(:item).permit(:image, :name, :explanation, :category_id, :situation_id, :load_id, :prefecture_id,
                                  :delivery_id, :price).merge(user_id: current_user.id)
   end
+end
+
+def check_user
+  return if current_user.id == @item.user_id
+
+  redirect_to root_path, alert: '他のユーザーの情報を編集することはできません。'
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,7 +3,7 @@ class Item < ApplicationRecord
 
   # テーブルとのアソシエーション
   belongs_to :user
-  # has_one    :purchase
+  has_one    :purchase
   has_many   :comments
 
   # アクティブハッシュとのアソシエーション

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -1,5 +1,5 @@
 class Purchase < ApplicationRecord
   # belongs_to :user
-  # belongs_to :item
+  belongs_to :item
   # has_one :address
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -139,7 +139,7 @@
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "出品する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', root_path, class:"back-btn" %>
+      <%=link_to 'もどる', item_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -55,7 +55,7 @@
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:situation_id, situation.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:situation_id, Situation.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
     <% if user_signed_in? %>
       <%# 出品者かつ未購入品であれば、編集・削除を表示 %>
       <% if current_user.id == @item.user_id %>
-        <%= link_to "商品の編集", '#', method: :get, class: "item-red-btn" %>
+        <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to '削除', '#', method: :delete, class: "item-destroy" %>
       <% else %>


### PR DESCRIPTION
WHAT:商品情報編集機能
WHY:商品情報編集機能の実装のため

■ログイン状態の出品者は商品情報編集ページに遷移できる動画
https://gyazo.com/e014df26736f359da6713a8f1bb3f1bd

■必要な情報を適切に入力して「更新する」ボタンを押すと商品の情報を編集できる動画
https://gyazo.com/fef1d5952664a7fee6c27846dcc10d6e

■入力に問題がある状態で「更新する」ボタンを押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
【修正前】
https://gyazo.com/34b515648b30d8998dfef806d43c4f66
【修正後】
https://gyazo.com/88a9c90274ada7c8949e9e87a4917947

■ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/715b89369d78efd144ec1716b5df3584

■ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/c7b4f8d9453a1ccb68cf21639c03d542

■■何も編集せずに「更新する」ボタンを押しても、画像なしの商品にならない動画
商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
https://gyazo.com/b6c0f8c7b75db7a3c023d125cf09e4a5